### PR TITLE
Use S6 to manage services in the Docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,18 @@
 FROM gliderlabs/alpine:3.2
 
-RUN apk --update add haproxy bash
+# Necessary depedencies
+RUN apk --update add haproxy bash curl tar
 
+# Install S6 from static bins
+RUN cd / && curl -L https://github.com/just-containers/skaware/releases/download/v1.17.1/s6-eeb0f9098450dbe470fc9b60627d15df62b04239-linux-amd64-bin.tar.gz | tar -xvzf -
+
+# Set up Sidecar
 ADD sidecar /sidecar/sidecar
 ADD sidecar.toml /sidecar/sidecar.toml
 ADD views /sidecar/views
 ADD start.sh /start.sh
+ADD s6 /etc
 
 EXPOSE 7777
-WORKDIR /sidecar
 
-ENTRYPOINT ["/start.sh"]
+CMD ["/bin/s6-svscan", "/etc/services"]

--- a/docker/s6/services/.s6-svscan/crash
+++ b/docker/s6/services/.s6-svscan/crash
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Container shutting down"

--- a/docker/s6/services/sidecar.svc/run
+++ b/docker/s6/services/sidecar.svc/run
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# stderr -> stdout
+exec 2>&1
+
+cd /sidecar
+
+for entry in $SIDECAR_SEEDS; do
+	CLI="$CLI --cluster-ip $entry"
+done
+
+if [[ -n "$SIDECAR_ADVERTISE_IP" ]]; then
+	CLI="$CLI --advertise-ip $SIDECAR_ADVERTISE_IP"
+fi
+
+BIND_IP=`grep bind_ip sidecar.toml | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*"`
+
+# If there's a BIND_IP and we don't already have it, add the
+# address to the loopback interface.
+if [[ -n $BIND_IP ]] && [[ $BIND_IP != "0.0.0.0" ]] || [[ ! ip addr show | grep $BIND_IP ]]; then
+	echo "Adding $BIND_IP to the loopback interface"
+	ip addr add $BIND_IP/32 dev lo
+fi
+
+exec ./sidecar $CLI


### PR DESCRIPTION
This uses the simple process supervisor S6 to manage the process inside the container. It's a tiny, statically linked replacement for `init` but with capabilities like `supervisord`.

@dselans @actaeon 