### PR TITLE
Add option to change HAProxy mode to tcp if desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ container itself. This is accomplished with another Docker label like so:
 	SidecarDiscover=false
 ```
 
+By default, HAProxy will run in HTTP mode. The mode can be changed to TCP by setting the following Docker label:
+
+```
+HAProxyMode=tcp
+```
+
 ####Configuring Static Discovery
 
 Static Discovery requires a configuration block in the `sidecar.toml` that

--- a/haproxy/haproxy_test.go
+++ b/haproxy/haproxy_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/smartystreets/goconvey/convey"
 	"github.com/newrelic/sidecar/catalog"
 	"github.com/newrelic/sidecar/service"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 var hostname1 = "indomitable"
@@ -33,35 +33,39 @@ func Test_HAproxy(t *testing.T) {
 
 		services := []service.Service{
 			service.Service{
-				ID:       svcId1,
-				Name:     "awesome-svc-adfffed1233",
-				Image:    "awesome-svc",
-				Hostname: hostname1,
-				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    ports1,
+				ID:          svcId1,
+				Name:        "awesome-svc-adfffed1233",
+				Image:       "awesome-svc",
+				Hostname:    hostname1,
+				Updated:     baseTime.Add(5 * time.Second),
+				HAProxyMode: "http",
+				Ports:       ports1,
 			},
 			service.Service{
-				ID:       svcId2,
-				Name:     "awesome-svc-1234fed1233",
-				Image:    "awesome-svc",
-				Hostname: hostname2,
-				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    ports1,
+				ID:          svcId2,
+				Name:        "awesome-svc-1234fed1233",
+				Image:       "awesome-svc",
+				Hostname:    hostname2,
+				Updated:     baseTime.Add(5 * time.Second),
+				HAProxyMode: "http",
+				Ports:       ports1,
 			},
 			service.Service{
-				ID:       svcId3,
-				Name:     "some-svc-0123456789a",
-				Image:    "some-svc",
-				Hostname: hostname2,
-				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    ports2,
+				ID:          svcId3,
+				Name:        "some-svc-0123456789a",
+				Image:       "some-svc",
+				Hostname:    hostname2,
+				Updated:     baseTime.Add(5 * time.Second),
+				HAProxyMode: "tcp",
+				Ports:       ports2,
 			},
 			service.Service{
-				ID:       svcId4,
-				Name:     "some-svc-befede6789a",
-				Image:    "some-svc",
-				Hostname: hostname2,
-				Updated:  baseTime.Add(5 * time.Second),
+				ID:          svcId4,
+				Name:        "some-svc-befede6789a",
+				Image:       "some-svc",
+				Hostname:    hostname2,
+				Updated:     baseTime.Add(5 * time.Second),
+				HAProxyMode: "tcp",
 				// No ports!
 			},
 		}
@@ -87,6 +91,15 @@ func Test_HAproxy(t *testing.T) {
 			So(len(result), ShouldEqual, 2)
 			So(len(result[services[0].Image]), ShouldEqual, 2)
 			So(len(result[services[2].Image]), ShouldEqual, 1)
+		})
+
+		Convey("getModes() generates a correct mode map", func() {
+			result := getModes(state)
+			fmt.Println(result)
+
+			So(len(result), ShouldEqual, 2)
+			So(result["awesome-svc"], ShouldEqual, "http")
+			So(result["some-svc"], ShouldEqual, "tcp")
 		})
 
 		Convey("servicesWithPorts() groups services by name and port", func() {

--- a/service/service.go
+++ b/service/service.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/newrelic/sidecar/output"
-	log "github.com/Sirupsen/logrus"
 )
 
 const (
@@ -27,14 +27,15 @@ type Port struct {
 }
 
 type Service struct {
-	ID       string
-	Name     string
-	Image    string
-	Created  time.Time
-	Hostname string
-	Ports    []Port
-	Updated  time.Time
-	Status   int
+	ID          string
+	Name        string
+	Image       string
+	Created     time.Time
+	Hostname    string
+	Ports       []Port
+	Updated     time.Time
+	HAProxyMode string
+	Status      int
 }
 
 func (svc Service) Encode() ([]byte, error) {
@@ -120,6 +121,12 @@ func ToService(container *docker.APIContainers) Service {
 	svc.Updated = time.Now().UTC()
 	svc.Hostname = hostname
 	svc.Status = ALIVE
+
+	if _, ok := container.Labels["HAProxyMode"]; ok {
+		svc.HAProxyMode = container.Labels["HAProxyMode"]
+	} else {
+		svc.HAProxyMode = "http"
+	}
 
 	svc.Ports = make([]Port, 0)
 

--- a/views/haproxy.cfg
+++ b/views/haproxy.cfg
@@ -38,12 +38,12 @@ backend stats
 {{ range $svcName, $services := .Services }} {{ range $svcPort, $port := getPorts $svcName }}
 # ----------- {{ $svcName }} port {{ $svcPort }} --------------
 frontend {{ sanitizeName $svcName }}-{{ $svcPort }}
-	mode http
+	mode {{ getMode $svcName}}
 	bind {{ bindIP }}:{{ $svcPort }}
 	default_backend {{ sanitizeName $svcName }}-{{ $svcPort }}
 
 backend {{ sanitizeName $svcName }}-{{ $svcPort }}
-	mode http {{ range $services }}
+	mode {{ getMode $svcName }} {{ range $services }}
 	server {{ .Hostname }}-{{ .ID }} {{ .Hostname }}:{{ $port }} cookie {{ .Hostname }}-{{ $port }} {{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
This will add the option to change the HAProxy mode from
HTTP to TCP by setting the "HAProxyMode=tcp" Docker label.

If no "HAProxyMode" label is included, the mode will default to
HTTP, which is the current default.

Includes additional test block, and README additions.

(BTW, the Dockerized version of Sidecar is fantastic, great work.)