### PR TITLE
Use more generic field name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ container itself. This is accomplished with another Docker label like so:
 By default, HAProxy will run in HTTP mode. The mode can be changed to TCP by setting the following Docker label:
 
 ```
-HAProxyMode=tcp
+ProxyMode=tcp
 ```
 
 Finally, you sometimes need to pass information in the Docker labels which

--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -177,7 +177,7 @@ func getModes(state *catalog.ServicesState) map[string]string {
 	state.EachServiceSorted(
 		func(hostname *string, serviceId *string, svc *service.Service) {
 			svcName := state.ServiceName(svc)
-			modeMap[svcName] = svc.HAProxyMode
+			modeMap[svcName] = svc.ProxyMode
 		},
 	)
 	return modeMap

--- a/haproxy/haproxy_test.go
+++ b/haproxy/haproxy_test.go
@@ -38,7 +38,7 @@ func Test_HAproxy(t *testing.T) {
 				Image:       "awesome-svc",
 				Hostname:    hostname1,
 				Updated:     baseTime.Add(5 * time.Second),
-				HAProxyMode: "http",
+				ProxyMode: "http",
 				Ports:       ports1,
 			},
 			service.Service{
@@ -47,7 +47,7 @@ func Test_HAproxy(t *testing.T) {
 				Image:       "awesome-svc",
 				Hostname:    hostname2,
 				Updated:     baseTime.Add(5 * time.Second),
-				HAProxyMode: "http",
+				ProxyMode: "http",
 				Ports:       ports1,
 			},
 			service.Service{
@@ -56,7 +56,7 @@ func Test_HAproxy(t *testing.T) {
 				Image:       "some-svc",
 				Hostname:    hostname2,
 				Updated:     baseTime.Add(5 * time.Second),
-				HAProxyMode: "tcp",
+				ProxyMode: "tcp",
 				Ports:       ports2,
 			},
 			service.Service{
@@ -65,7 +65,7 @@ func Test_HAproxy(t *testing.T) {
 				Image:       "some-svc",
 				Hostname:    hostname2,
 				Updated:     baseTime.Add(5 * time.Second),
-				HAProxyMode: "tcp",
+				ProxyMode: "tcp",
 				// No ports!
 			},
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -34,7 +34,7 @@ type Service struct {
 	Hostname    string
 	Ports       []Port
 	Updated     time.Time
-	HAProxyMode string
+	ProxyMode string
 	Status      int
 }
 
@@ -122,10 +122,10 @@ func ToService(container *docker.APIContainers) Service {
 	svc.Hostname = hostname
 	svc.Status = ALIVE
 
-	if _, ok := container.Labels["HAProxyMode"]; ok {
-		svc.HAProxyMode = container.Labels["HAProxyMode"]
+	if _, ok := container.Labels["ProxyMode"]; ok {
+		svc.ProxyMode = container.Labels["ProxyMode"]
 	} else {
-		svc.HAProxyMode = "http"
+		svc.ProxyMode = "http"
 	}
 
 	svc.Ports = make([]Port, 0)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -98,7 +98,7 @@ func Test_ToService(t *testing.T) {
 		Names:      []string{"/sample-app-go-worker-eebb5aad1a17ee"},
 		Labels: map[string]string{
 			"ServicePort_8080": "17010",
-			"HAProxyMode":      "tcp",
+			"ProxyMode":      "tcp",
 			"HealthCheck":      "HttpGet",
 			"HealthCheckArgs":  "http://127.0.0.1:39519/status/check",
 		},
@@ -125,7 +125,7 @@ func Test_ToService(t *testing.T) {
 			So(service.Hostname, ShouldEqual, sampleHostname)
 			So(reflect.DeepEqual(samplePorts, service.Ports), ShouldBeTrue)
 			So(service.Updated, ShouldNotBeNil)
-			So(service.HAProxyMode, ShouldEqual, "tcp")
+			So(service.ProxyMode, ShouldEqual, "tcp")
 			So(service.Status, ShouldEqual, 0)
 		})
 	})


### PR DESCRIPTION
What if we support Nginx? The field name needs to be more generic. This affects anything that is currently using the `HAProxyMode` Docker label or that field in static discovery.

@actaeon 