### PR TITLE
Make logging somewhat cleaner and much less of it.

### DIFF
--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -131,11 +131,11 @@ func (state *ServicesState) GetLocalService(id string) *service.Service {
 // A server has left the cluster, so tombstone all of its records
 func (state *ServicesState) ExpireServer(hostname string) {
 	if !state.HasServer(hostname) {
-		log.Printf("No records to expire for %s", hostname)
+		log.Infof("No records to expire for %s", hostname)
 		return
 	}
 
-	log.Printf("Expiring %s", hostname)
+	log.Infof("Expiring %s", hostname)
 
 	tombstones := make([]service.Service, 0, len(state.Servers[hostname].Services))
 
@@ -344,7 +344,7 @@ func (state *ServicesState) BroadcastServices(fn func() []service.Service, loope
 		}
 
 		if len(services) > 0 {
-			log.Println("Starting to broadcast")
+			log.Debug("Starting to broadcast")
 			// Figure out how many times to announce the service. New services get more announcements.
 			runCount := 1
 			if haveNewServices {
@@ -356,7 +356,7 @@ func (state *ServicesState) BroadcastServices(fn func() []service.Service, loope
 				services,
 				director.NewTimedLooper(runCount, state.tombstoneRetransmit, nil),
 			)
-			log.Println("Completing broadcast")
+			log.Debug("Completing broadcast")
 		} else {
 			// We expect there to always be _something_ in the channel
 			// once we've run.

--- a/services_delegate.go
+++ b/services_delegate.go
@@ -44,7 +44,7 @@ func NewServicesDelegate(state *catalog.ServicesState) *servicesDelegate {
 }
 
 func (d *servicesDelegate) NodeMeta(limit int) []byte {
-	log.Printf("NodeMeta(): %d", limit)
+	log.Debugf("NodeMeta(): %d", limit)
 	data, err := json.Marshal(d.Metadata)
 	if err != nil {
 		log.Error("Error encoding Node metadata!")
@@ -61,7 +61,7 @@ func (d *servicesDelegate) NotifyMsg(message []byte) {
 		return
 	}
 
-	log.Printf("NotifyMsg(): %s", string(message))
+	log.Debugf("NotifyMsg(): %s", string(message))
 
 	// TODO don't just send container structs, send message structs
 	d.notifications <- message
@@ -74,7 +74,7 @@ func (d *servicesDelegate) NotifyMsg(message []byte) {
 			for message := range d.notifications {
 				entry := service.Decode(message)
 				if entry == nil {
-					log.Printf("NotifyMsg(): error decoding!")
+					log.Errorf("NotifyMsg(): error decoding!")
 					continue
 				}
 				d.state.AddServiceEntry(*entry)
@@ -119,7 +119,7 @@ func (d *servicesDelegate) GetBroadcasts(overhead, limit int) [][]byte {
 		return nil
 	}
 
-	log.Printf("Sending broadcast %d msgs %d 1st length",
+	log.Debugf("Sending broadcast %d msgs %d 1st length",
 		len(broadcast), len(broadcast[0]),
 	)
 	if len(leftover) > 0 {
@@ -130,14 +130,15 @@ func (d *servicesDelegate) GetBroadcasts(overhead, limit int) [][]byte {
 }
 
 func (d *servicesDelegate) LocalState(join bool) []byte {
-	log.Printf("LocalState(): %b", join)
+	log.Debugf("LocalState(): %b", join)
 	return d.state.Encode()
 }
 
 func (d *servicesDelegate) MergeRemoteState(buf []byte, join bool) {
 	defer metrics.MeasureSince([]string{"delegate", "MergeRemoteState"}, time.Now())
 
-	log.Printf("MergeRemoteState(): %s %b", string(buf), join)
+	log.Info("Merging remote state...")
+	log.Debugf("MergeRemoteState(): %s %b", string(buf), join)
 
 	otherState, err := catalog.Decode(buf)
 	if err != nil {
@@ -145,7 +146,7 @@ func (d *servicesDelegate) MergeRemoteState(buf []byte, join bool) {
 		return
 	}
 
-	log.Printf("Merging state: %s", otherState.Format(nil))
+	log.Debugf("Merging state: %s", otherState.Format(nil))
 
 	d.state.Merge(otherState)
 }

--- a/sidecar.go
+++ b/sidecar.go
@@ -30,7 +30,7 @@ func announceMembers(list *memberlist.Memberlist, state *catalog.ServicesState) 
 			log.Printf("Meta: %s", string(member.Meta))
 		}
 
-		state.Print(list)
+		log.Debug(state.Format(list))
 
 		time.Sleep(2 * time.Second)
 	}


### PR DESCRIPTION
I know @actaeon you're not going to complain about this change. ;)  Should reduce logging output a lot. Sidecar is very verbose at the moment in info mode which is not great for production installations.

Appears to cut Sidecar logging by ~two thirds:

```
image                    line count
gonitro/sidecar:191f36b  2,636
gonitro/sidecar:f6d542a  7,438
```
That's comparing log lines outputted from the current `master` and from `less-verbose-logging` with two hosts in the cluster. That's one 15 minute period.