### PR TITLE
Flexible Container Naming

### DIFF
--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/newrelic/sidecar/service"
 	"github.com/relistan/go-director"
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/newrelic/sidecar/service"
 )
 
 var hostname = "shakespeare"

--- a/catalog/view_test.go
+++ b/catalog/view_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/smartystreets/goconvey/convey"
 	"github.com/newrelic/sidecar/service"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 var (

--- a/config.go
+++ b/config.go
@@ -20,8 +20,6 @@ type HAproxyConfig struct {
 }
 
 type ServicesConfig struct {
-	NameMatch  string `toml:"name_match"`
-	NameRegexp *regexp.Regexp
 }
 
 type SidecarConfig struct {
@@ -35,7 +33,10 @@ type SidecarConfig struct {
 }
 
 type DockerConfig struct {
-	DockerURL string `toml:"docker_url"`
+	DockerURL     string `toml:"docker_url"`
+	NameFromLabel string `toml:"name_from_label"`
+	NameMatch     string `toml:"name_match"`
+	NameRegexp    *regexp.Regexp
 }
 
 type StaticConfig struct {
@@ -75,7 +76,7 @@ func parseConfig(path string) Config {
 		exitWithError(err, "Failed to parse config file")
 	}
 
-	config.Services.NameRegexp, err = regexp.Compile(config.Services.NameMatch)
+	config.DockerDiscovery.NameRegexp, err = regexp.Compile(config.DockerDiscovery.NameMatch)
 	exitWithError(err, "Cant compile name_match regex")
 
 	return config

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -3,8 +3,8 @@ package discovery
 import (
 	"time"
 
-	"github.com/relistan/go-director"
 	"github.com/newrelic/sidecar/service"
+	"github.com/relistan/go-director"
 )
 
 const (

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -3,9 +3,9 @@ package discovery
 import (
 	"testing"
 
+	"github.com/newrelic/sidecar/service"
 	"github.com/relistan/go-director"
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/newrelic/sidecar/service"
 )
 
 type mockDiscoverer struct {
@@ -45,8 +45,8 @@ func Test_MultiDiscovery(t *testing.T) {
 		svc1 := service.Service{Name: "svc1"}
 		svc2 := service.Service{Name: "svc2"}
 
-		disco1 := &mockDiscoverer{ []service.Service{ svc1 }, false, false, done1, "one" }
-		disco2 := &mockDiscoverer{ []service.Service{ svc2 }, false, false, done2, "two" }
+		disco1 := &mockDiscoverer{[]service.Service{svc1}, false, false, done1, "one"}
+		disco2 := &mockDiscoverer{[]service.Service{svc2}, false, false, done2, "two"}
 
 		multi := &MultiDiscovery{[]Discoverer{disco1, disco2}}
 

--- a/discovery/docker_discovery.go
+++ b/discovery/docker_discovery.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"fmt"
+	"regexp"
 	"sync"
 	"time"
 
@@ -15,6 +16,15 @@ import (
 const (
 	CACHE_DRAIN_INTERVAL = 10 * time.Minute // Drain the cache every 10 mins
 )
+
+type namer struct {
+	NamingFunction func() string
+	Container      docker.APIContainers
+}
+
+func (n namer) Name() string {
+	return n.NamingFunction()
+}
 
 type DockerClient interface {
 	InspectContainer(id string) (*docker.Container, error)
@@ -30,12 +40,20 @@ type DockerDiscovery struct {
 	services       []*service.Service           // The list of services we know about
 	ClientProvider func() (DockerClient, error) // Return the client we'll use to connect
 	containerCache map[string]*docker.Container // Cache of inspected containers
-	sync.RWMutex                                // Reader/Writer lock
+	nameFromEnvVar string
+	nameFromLabel  string
+	nameMatch      string
+	nameRegexp     *regexp.Regexp
+	sync.RWMutex   // Reader/Writer lock
 }
 
-func NewDockerDiscovery(endpoint string) *DockerDiscovery {
+func NewDockerDiscovery(endpoint, nameFromLabel, nameMatch string, nameRegexp *regexp.Regexp) *DockerDiscovery {
+
 	discovery := DockerDiscovery{
 		endpoint:       endpoint,
+		nameFromLabel:  nameFromLabel,
+		nameMatch:      nameMatch,
+		nameRegexp:     nameRegexp,
 		events:         make(chan *docker.APIEvents),
 		containerCache: make(map[string]*docker.Container),
 	}
@@ -163,7 +181,49 @@ func (d *DockerDiscovery) getContainers() {
 			continue
 		}
 
-		svc := service.ToService(&container)
+		n := &namer{
+			Container: container,
+			NamingFunction: func() string {
+				log.Debug("Getting container name")
+
+				if d.nameMatch != "" {
+					log.Debug("doing nameMatch")
+
+					// Use Custom Matcher to group containers by
+					// Regex on the container name
+
+					toMatch := []byte(container.Names[0])
+					matches := d.nameRegexp.FindSubmatch(toMatch)
+					if len(matches) < 1 {
+						return container.Image
+					} else {
+						return string(matches[1])
+					}
+
+				} else if d.nameFromLabel != "" {
+					log.Debugf("Using container label %s", d.nameFromLabel)
+
+					// Use a specific container label as the name
+
+					if labelValue, ok := container.Labels[d.nameFromLabel]; ok {
+						log.Debug("LabelValue: %s", labelValue)
+						return labelValue
+					} else {
+						log.Debug("Container Label %s not found, using image", d.nameFromLabel)
+						return container.Image
+					}
+
+				} else {
+
+					// use Image as a fall-back, this is undesireable
+					// because LB won't won (each container will be a VIP of one)
+
+					return container.Image
+				}
+			},
+		}
+
+		svc := service.ToService(&container, n)
 		d.services = append(d.services, &svc)
 		containerMap[svc.ID] = true
 	}
@@ -173,7 +233,7 @@ func (d *DockerDiscovery) getContainers() {
 
 // Loop through the current cache and remove anything that has disappeared
 func (d *DockerDiscovery) pruneContainerCache(liveContainers map[string]interface{}) {
-	for id, _ := range d.containerCache {
+	for id := range d.containerCache {
 		if _, ok := liveContainers[id]; !ok {
 			delete(d.containerCache, id)
 		}

--- a/discovery/static_discovery_test.go
+++ b/discovery/static_discovery_test.go
@@ -3,9 +3,9 @@ package discovery
 import (
 	"testing"
 
+	"github.com/newrelic/sidecar/service"
 	"github.com/relistan/go-director"
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/newrelic/sidecar/service"
 )
 
 const (

--- a/docker/sidecar.docker.toml
+++ b/docker/sidecar.docker.toml
@@ -5,11 +5,11 @@ push_pull_interval = "20s"
 
 [docker_discovery]
 docker_url = "unix:///var/run/docker.sock"
+name_from_label = "ServiceName"
 
 [services]
 # Centurion format, looks like: service-name-deadbeef12312
 # returns first match: "service-name"
-name_match = "^/(.+)(-[0-9a-z]{7,14})$"
 
 [haproxy]
 bind_ip       = "192.168.168.168"

--- a/haproxy/haproxy_test.go
+++ b/haproxy/haproxy_test.go
@@ -28,43 +28,43 @@ func Test_HAproxy(t *testing.T) {
 		svcId4 := "deadbeef999"
 		baseTime := time.Now().UTC().Round(time.Second)
 
-		ports1 := []service.Port{service.Port{"tcp", 10450, 8080}, service.Port{"tcp", 10020, 9000}}
-		ports2 := []service.Port{service.Port{"tcp", 9999, 8090}}
+		ports1 := []service.Port{{"tcp", 10450, 8080}, {"tcp", 10020, 9000}}
+		ports2 := []service.Port{{"tcp", 9999, 8090}}
 
 		services := []service.Service{
-			service.Service{
-				ID:          svcId1,
-				Name:        "awesome-svc-adfffed1233",
-				Image:       "awesome-svc",
-				Hostname:    hostname1,
-				Updated:     baseTime.Add(5 * time.Second),
+			{
+				ID:        svcId1,
+				Name:      "awesome-svc-adfffed1233",
+				Image:     "awesome-svc",
+				Hostname:  hostname1,
+				Updated:   baseTime.Add(5 * time.Second),
 				ProxyMode: "http",
-				Ports:       ports1,
+				Ports:     ports1,
 			},
-			service.Service{
-				ID:          svcId2,
-				Name:        "awesome-svc-1234fed1233",
-				Image:       "awesome-svc",
-				Hostname:    hostname2,
-				Updated:     baseTime.Add(5 * time.Second),
+			{
+				ID:        svcId2,
+				Name:      "awesome-svc-1234fed1233",
+				Image:     "awesome-svc",
+				Hostname:  hostname2,
+				Updated:   baseTime.Add(5 * time.Second),
 				ProxyMode: "http",
-				Ports:       ports1,
+				Ports:     ports1,
 			},
-			service.Service{
-				ID:          svcId3,
-				Name:        "some-svc-0123456789a",
-				Image:       "some-svc",
-				Hostname:    hostname2,
-				Updated:     baseTime.Add(5 * time.Second),
+			{
+				ID:        svcId3,
+				Name:      "some-svc-0123456789a",
+				Image:     "some-svc",
+				Hostname:  hostname2,
+				Updated:   baseTime.Add(5 * time.Second),
 				ProxyMode: "tcp",
-				Ports:       ports2,
+				Ports:     ports2,
 			},
-			service.Service{
-				ID:          svcId4,
-				Name:        "some-svc-befede6789a",
-				Image:       "some-svc",
-				Hostname:    hostname2,
-				Updated:     baseTime.Add(5 * time.Second),
+			{
+				ID:        svcId4,
+				Name:      "some-svc-befede6789a",
+				Image:     "some-svc",
+				Hostname:  hostname2,
+				Updated:   baseTime.Add(5 * time.Second),
 				ProxyMode: "tcp",
 				// No ports!
 			},
@@ -109,7 +109,7 @@ func Test_HAproxy(t *testing.T) {
 				Image:    "some-svc",
 				Hostname: "titanic",
 				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    []service.Port{service.Port{"tcp", 666, 6666}},
+				Ports:    []service.Port{{"tcp", 666, 6666}},
 			}
 
 			svcName := state.ServiceName(&badSvc)
@@ -147,7 +147,7 @@ func Test_HAproxy(t *testing.T) {
 				Hostname: "titanic",
 				Status:   service.UNHEALTHY,
 				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    []service.Port{service.Port{"tcp", 666, 6666}},
+				Ports:    []service.Port{{"tcp", 666, 6666}},
 			}
 			badSvc2 := service.Service{
 				ID:       "0000bad00001",
@@ -156,7 +156,7 @@ func Test_HAproxy(t *testing.T) {
 				Hostname: "titanic",
 				Status:   service.UNKNOWN,
 				Updated:  baseTime.Add(5 * time.Second),
-				Ports:    []service.Port{service.Port{"tcp", 666, 6666}},
+				Ports:    []service.Port{{"tcp", 666, 6666}},
 			}
 			state.AddServiceEntry(badSvc)
 			state.AddServiceEntry(badSvc2)
@@ -205,7 +205,7 @@ func Test_HAproxy(t *testing.T) {
 				Image:    "some-svc",
 				Hostname: hostname2,
 				Updated:  newTime,
-				Ports:    []service.Port{service.Port{"tcp", 1337, 8090}},
+				Ports:    []service.Port{{"tcp", 1337, 8090}},
 			}
 			time.Sleep(5 * time.Millisecond)
 			state.AddServiceEntry(svc)

--- a/healthy/healthy.go
+++ b/healthy/healthy.go
@@ -128,12 +128,11 @@ func (check *Check) ServiceStatus() int {
 }
 
 // NewMonitor returns a properly configured default configuration of a Monitor.
-func NewMonitor(defaultCheckHost string, defaultCheckEndpoint string) *Monitor {
+func NewMonitor(defaultCheckHost string) *Monitor {
 	monitor := Monitor{
-		Checks:               make(map[string]*Check, 5),
-		CheckInterval:        HEALTH_INTERVAL,
-		DefaultCheckHost:     defaultCheckHost,
-		DefaultCheckEndpoint: defaultCheckEndpoint,
+		Checks:           make(map[string]*Check, 5),
+		CheckInterval:    HEALTH_INTERVAL,
+		DefaultCheckHost: defaultCheckHost,
 	}
 	return &monitor
 }

--- a/healthy/healthy_test.go
+++ b/healthy/healthy_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/newrelic/sidecar/service"
 	"github.com/relistan/go-director"
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/newrelic/sidecar/service"
 )
 
 func Test_NewCheck(t *testing.T) {
@@ -186,11 +186,11 @@ func Test_MarkingServices(t *testing.T) {
 		// Then we health check them and look at the results carefully.
 		monitor := NewMonitor(hostname, "/")
 		services := []service.Service{
-			service.Service{ID: "test", Status: service.ALIVE},
-			service.Service{ID: "bad", Status: service.ALIVE},
-			service.Service{ID: "unknown", Status: service.ALIVE},
-			service.Service{ID: "test2", Status: service.TOMBSTONE},
-			service.Service{ID: "unknown2", Status: service.UNKNOWN},
+			{ID: "test", Status: service.ALIVE},
+			{ID: "bad", Status: service.ALIVE},
+			{ID: "unknown", Status: service.ALIVE},
+			{ID: "test2", Status: service.TOMBSTONE},
+			{ID: "unknown2", Status: service.UNKNOWN},
 		}
 
 		looper := director.NewFreeLooper(director.ONCE, nil)

--- a/healthy/service_bridge_test.go
+++ b/healthy/service_bridge_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/newrelic/sidecar/service"
 	"github.com/relistan/go-director"
 	. "github.com/smartystreets/goconvey/convey"
-	"github.com/newrelic/sidecar/service"
 )
 
 var hostname string = "indefatigable"
@@ -27,7 +27,7 @@ func (m *mockDiscoverer) HealthCheck(svc *service.Service) (string, string) {
 	return "", ""
 }
 
-func (m *mockDiscoverer) Run(director.Looper) { }
+func (m *mockDiscoverer) Run(director.Looper) {}
 
 func Test_ServicesBridge(t *testing.T) {
 	Convey("The services bridge", t, func() {
@@ -128,11 +128,11 @@ func Test_ServicesBridge(t *testing.T) {
 		Convey("Responds to changes in a list of services", func() {
 			So(len(monitor.Checks), ShouldEqual, 4)
 
-			ports := []service.Port{service.Port{"udp", 11234, 8080}, service.Port{"tcp", 1234, 8081}}
+			ports := []service.Port{{"udp", 11234, 8080}, {"tcp", 1234, 8081}}
 			svc := service.Service{ID: "babbacabba", Name: "testing-12312312", Ports: ports}
 			svcList := []service.Service{svc}
 
-			disco := &mockDiscoverer{ listFn: func() []service.Service { return svcList } }
+			disco := &mockDiscoverer{listFn: func() []service.Service { return svcList }}
 
 			cmd := HttpGetCmd{}
 			check := &Check{
@@ -156,8 +156,8 @@ func Test_CheckForService(t *testing.T) {
 	Convey("When building a default check", t, func() {
 		svcId1 := "deadbeef123"
 		ports := []service.Port{
-			service.Port{"udp", 11234, 8080},
-			service.Port{"tcp", 1234, 8081},
+			{"udp", 11234, 8080},
+			{"tcp", 1234, 8081},
 		}
 		service1 := service.Service{ID: svcId1, Hostname: hostname, Ports: ports}
 

--- a/http.go
+++ b/http.go
@@ -90,7 +90,7 @@ func portsStr(svcPorts []service.Port) string {
 	var ports []string
 
 	for _, port := range svcPorts {
-	    if port.ServicePort != 0 {
+		if port.ServicePort != 0 {
 			ports = append(ports, fmt.Sprintf("%v->%v", port.ServicePort, port.Port))
 		} else {
 			ports = append(ports, fmt.Sprintf("%v", port.Port))

--- a/service/service.go
+++ b/service/service.go
@@ -20,6 +20,10 @@ const (
 	UNKNOWN   = iota
 )
 
+type Namer interface {
+	Name() string
+}
+
 type Port struct {
 	Type        string
 	Port        int64
@@ -27,15 +31,15 @@ type Port struct {
 }
 
 type Service struct {
-	ID          string
-	Name        string
-	Image       string
-	Created     time.Time
-	Hostname    string
-	Ports       []Port
-	Updated     time.Time
+	ID        string
+	Name      string
+	Image     string
+	Created   time.Time
+	Hostname  string
+	Ports     []Port
+	Updated   time.Time
 	ProxyMode string
-	Status      int
+	Status    int
 }
 
 func (svc Service) Encode() ([]byte, error) {
@@ -110,12 +114,13 @@ func Decode(data []byte) *Service {
 
 // Format an APIContainers struct into a more compact struct we
 // can ship over the wire in a broadcast.
-func ToService(container *docker.APIContainers) Service {
+func ToService(container *docker.APIContainers, namer Namer) Service {
 	var svc Service
 	hostname, _ := os.Hostname()
 
-	svc.ID = container.ID[0:12]   // Use short IDs
-	svc.Name = container.Names[0] // Use the first name
+	svc.ID = container.ID[0:12] // Use short IDs
+	//	svc.Name = container.Names[0] // Use the first name
+	svc.Name = namer.Name()
 	svc.Image = container.Image
 	svc.Created = time.Unix(container.Created, 0).UTC()
 	svc.Updated = time.Now().UTC()

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -80,13 +80,13 @@ func Test_ToService(t *testing.T) {
 		Created: 1457144774,
 		Status:  "Up 34 seconds",
 		Ports: []docker.APIPort{
-			docker.APIPort{
+			{
 				PrivatePort: 9990,
 				PublicPort:  0,
 				Type:        "tcp",
 				IP:          "",
 			},
-			docker.APIPort{
+			{
 				PrivatePort: 8080,
 				PublicPort:  31355,
 				Type:        "tcp",
@@ -98,14 +98,14 @@ func Test_ToService(t *testing.T) {
 		Names:      []string{"/sample-app-go-worker-eebb5aad1a17ee"},
 		Labels: map[string]string{
 			"ServicePort_8080": "17010",
-			"ProxyMode":      "tcp",
+			"ProxyMode":        "tcp",
 			"HealthCheck":      "HttpGet",
 			"HealthCheckArgs":  "http://127.0.0.1:39519/status/check",
 		},
 	}
 
 	samplePorts := []Port{
-		Port{
+		{
 			Type:        "tcp",
 			Port:        31355,
 			ServicePort: 17010,


### PR DESCRIPTION
@relistan 

I'll write the tests for this if you think something like this would be ok.

This moves the container naming logic into DockerDiscovery and
injects a naming function into Service. Naming is controlled by
setting one of:

[DockerConfig]
name_from_label = set the container name to the value of the
                  container label with key matching this sting
name_match      = [ DEFAULT ] regex to use for grouping about the container
                  name.

This should be backwards compatible.