### PR TITLE
Fix for services with no bound ports.

### DIFF
--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -323,8 +323,8 @@ func (state *ServicesState) IsNewService(svc *service.Service) bool {
 	return false
 }
 
-// Loops forever, keeping transmitting info about our containers
-// on the broadcast channel. Intended to run as a background goroutine.
+// Loops forever, transmitting info about our containers on the
+// broadcast channel. Intended to run as a background goroutine.
 func (state *ServicesState) BroadcastServices(fn func() []service.Service, looper director.Looper) {
 	lastTime := time.Unix(0, 0)
 
@@ -338,11 +338,12 @@ func (state *ServicesState) BroadcastServices(fn func() []service.Service, loope
 		for _, svc := range servicesList {
 			isNew := state.IsNewService(&svc)
 
+			// We'll broadcast it now if it's new or we've hit refresh window
 			if isNew {
 				log.Println("Found service changes!")
 				haveNewServices = true
 				services = append(services, svc)
-				// We'll broadcast it now if it's new or we've hit refresh window
+			// Check that refresh window... is it time?
 			} else if time.Now().UTC().Add(0 - ALIVE_BROADCAST_INTERVAL).After(lastTime) {
 				services = append(services, svc)
 			}

--- a/healthy/commands.go
+++ b/healthy/commands.go
@@ -53,3 +53,12 @@ func (e *ExternalCmd) Run(args string) (int, error) {
 	log.Errorf("Error running command: %s (%s)\n", err.Error(), output)
 	return SICKLY, err
 }
+
+// A Checker that always returns success. Usually used in
+// cases where a service can't actually be health checked for
+// some reason.
+type AlwaysSuccessfulCmd struct{}
+
+func (a *AlwaysSuccessfulCmd) Run(args string) (int, error) {
+	return HEALTHY, nil
+}

--- a/healthy/service_bridge.go
+++ b/healthy/service_bridge.go
@@ -50,7 +50,7 @@ func findFirstTCPPort(svc *service.Service) *service.Port {
 func (m *Monitor) defaultCheckForService(svc *service.Service) *Check {
 	port := findFirstTCPPort(svc)
 	if port == nil {
-		return &Check{ID: svc.ID}
+		return &Check{ID: svc.ID, Command: &AlwaysSuccessfulCmd{}}
 	}
 
 	// Use the const default unless we've been provided something else


### PR DESCRIPTION
Services that had no bound ports were generating a ton of errors as it re-attempted to add them on each pass over discovery. This PR adds a check command that always returns true. This is now the default for services for which no ports are found. This can still be overridden from discovery.