### PR TITLE
Flexible Container Naming Take 2

### DIFF
--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -544,7 +544,6 @@ func Example_ByServiceWithoutMatcher() {
 func Example_ByServiceWithMatcher() {
 	state := NewServicesState()
 	state.Servers[hostname] = NewServer(hostname)
-	state.ServiceNameMatch = regexp.MustCompile("^(.+)(-[0-9a-z]{7,14})$")
 	svcId1 := "deadbeef123"
 	svcId2 := "deadbeef101"
 	svcId3 := "deadbeef105"

--- a/config.go
+++ b/config.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"regexp"
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -24,8 +23,9 @@ type HAproxyConfig struct {
 }
 
 type ServicesConfig struct {
-	NameMatch  string `toml:"name_match"`
-	NameRegexp *regexp.Regexp
+	NameMatch    string `toml:"name_match"`
+	ServiceNamer string `toml:"service_namer"`
+	NameLabel    string `toml:"name_label"`
 }
 
 type SidecarConfig struct {
@@ -80,9 +80,6 @@ func parseConfig(path string) Config {
 	if err != nil {
 		exitWithError(err, "Failed to parse config file")
 	}
-
-	config.Services.NameRegexp, err = regexp.Compile(config.Services.NameMatch)
-	exitWithError(err, "Cant compile name_match regex")
 
 	return config
 }

--- a/config.go
+++ b/config.go
@@ -24,7 +24,7 @@ type HAproxyConfig struct {
 
 type ServicesConfig struct {
 	NameMatch    string `toml:"name_match"`
-	ServiceNamer string `toml:"service_namer"`
+	ServiceNamer string `toml:"namer"`
 	NameLabel    string `toml:"name_label"`
 }
 

--- a/discovery/docker_discovery_test.go
+++ b/discovery/docker_discovery_test.go
@@ -73,7 +73,9 @@ func Test_DockerDiscovery(t *testing.T) {
 			}, nil
 		}
 
-		disco := NewDockerDiscovery(endpoint)
+		svcNamer := &RegexpNamer{ServiceNameMatch: "^/(.+)(-[0-9a-z]{7,14})$"}
+
+		disco := NewDockerDiscovery(endpoint, svcNamer)
 		disco.ClientProvider = stubClientProvider
 
 		Convey("New() configures an endpoint and events channel", func() {

--- a/discovery/service_namer.go
+++ b/discovery/service_namer.go
@@ -1,0 +1,78 @@
+package discovery
+
+import (
+	"regexp"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/fsouza/go-dockerclient"
+)
+
+type ServiceNamer interface {
+	ServiceName(*docker.APIContainers) string
+}
+
+// A ServiceNamer that uses a regex to match against the service name
+// or else uses the image as the service name.
+type RegexpNamer struct {
+	ServiceNameMatch string
+	expression *regexp.Regexp
+}
+
+// Return a properly regex-matched name for the service, or failing that,
+// the Image ID which we use to stand in for the name of the service.
+func (r *RegexpNamer) ServiceName(container *docker.APIContainers) string {
+	if container == nil {
+		log.Warn("ServiceName() called with nil service passed!")
+		return ""
+	}
+
+	if r.expression == nil {
+		var err error
+
+		r.expression, err = regexp.Compile(r.ServiceNameMatch)
+		if err != nil {
+			log.Errorf("Invalid regex, can't compile: %s", r.ServiceNameMatch)
+			return  container.Image
+		}
+	}
+
+	var svcName string
+
+	toMatch := []byte(container.Names[0])
+	matches := r.expression.FindSubmatch(toMatch)
+	if len(matches) < 1 {
+		svcName = container.Image
+	} else {
+		svcName = string(matches[1])
+	}
+
+	return svcName
+}
+
+// A ServiceNamer that uses a name provided in a Docker label as the name
+// for the service.
+type DockerLabelNamer struct {
+	Label string
+}
+
+// Return the value of the configured Docker label, or default to the image
+// name.
+func (d *DockerLabelNamer) ServiceName(container *docker.APIContainers) string {
+	if container == nil {
+		log.Warn("ServiceName() called with nil service passed!")
+		return ""
+	}
+
+	for label, value := range container.Labels {
+		if label == d.Label {
+			return value
+		}
+	}
+
+	log.Warnf(
+		"Found container with no '%s' label: %s (%s), returning '%s'", d.Label,
+		container.ID, container.Names[0], container.Image,
+	)
+
+	return container.Image
+}

--- a/discovery/service_namer_test.go
+++ b/discovery/service_namer_test.go
@@ -1,0 +1,54 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/fsouza/go-dockerclient"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func Test_RegexpNamer(t *testing.T) {
+	Convey("RegexpNamer", t, func() {
+		container := &docker.APIContainers{
+			ID: "deadbeef001",
+			Image: "gonitro/awesome-svc:0.1.34",
+			Names: []string { "/awesome-svc-1231b1b12323" },
+			Labels: map[string]string{},
+		}
+
+		var namer ServiceNamer
+
+		Convey("Properly extracts a ServiceName", func() {
+			namer = &RegexpNamer{ ServiceNameMatch: "^/(.+)(-[0-9a-z]{7,14})$" }
+			So(namer.ServiceName(container), ShouldEqual, "awesome-svc")
+		})
+
+		Convey("Returns the image when the expression doesn't match", func() {
+			namer = &RegexpNamer{ ServiceNameMatch: "ASDF" }
+			So(namer.ServiceName(container), ShouldEqual, "gonitro/awesome-svc:0.1.34")
+		})
+	})
+}
+
+func Test_DockerLabelNamer(t *testing.T) {
+	Convey("DockerLabelNamer", t, func() {
+		container := &docker.APIContainers{
+			ID: "deadbeef001",
+			Image: "gonitro/awesome-svc:0.1.34",
+			Names: []string { "/awesome-svc-1231b1b12323" },
+			Labels: map[string]string{ "ServiceName": "awesome-svc-1" },
+		}
+
+		var namer ServiceNamer
+
+		Convey("Properly extracts a ServiceName", func() {
+			namer = &DockerLabelNamer{ Label: "ServiceName" }
+			So(namer.ServiceName(container), ShouldEqual, "awesome-svc-1")
+		})
+
+		Convey("Returns the image when the expression doesn't match", func() {
+			namer = &DockerLabelNamer{ Label: "ASDF" }
+			So(namer.ServiceName(container), ShouldEqual, "gonitro/awesome-svc:0.1.34")
+		})
+	})
+}

--- a/docker/sidecar.docker.toml
+++ b/docker/sidecar.docker.toml
@@ -8,9 +8,12 @@ logging_level = "info"
 docker_url = "unix:///var/run/docker.sock"
 
 [services]
+namer = "docker_label"
 # Centurion format, looks like: service-name-deadbeef12312
-# returns first match: "service-name"
+# returns first match: "service-name" . This is used only
+# when namer = "regex"
 name_match = "^/(.+)(-[0-9a-z]{7,14})$"
+name_label = "ServiceName"
 
 [haproxy]
 bind_ip       = "192.168.168.168"

--- a/haproxy/haproxy.go
+++ b/haproxy/haproxy.go
@@ -176,8 +176,7 @@ func getModes(state *catalog.ServicesState) map[string]string {
 	modeMap := make(map[string]string)
 	state.EachServiceSorted(
 		func(hostname *string, serviceId *string, svc *service.Service) {
-			svcName := state.ServiceName(svc)
-			modeMap[svcName] = svc.ProxyMode
+			modeMap[svc.Name] = svc.ProxyMode
 		},
 	)
 	return modeMap
@@ -200,19 +199,18 @@ func servicesWithPorts(state *catalog.ServicesState) map[string][]*service.Servi
 				return
 			}
 
-			svcName := state.ServiceName(svc)
-			if _, ok := serviceMap[svcName]; !ok {
-				serviceMap[svcName] = make([]*service.Service, 0, 3)
+			if _, ok := serviceMap[svc.Name]; !ok {
+				serviceMap[svc.Name] = make([]*service.Service, 0, 3)
 			}
 
 			// If this is the first one, just add it to the list
-			if len(serviceMap[svcName]) < 1 {
-				serviceMap[svcName] = append(serviceMap[svcName], svc)
+			if len(serviceMap[svc.Name]) < 1 {
+				serviceMap[svc.Name] = append(serviceMap[svc.Name], svc)
 				return
 			}
 
 			// Otherwise we need to make sure the ServicePorts match
-			match := serviceMap[svcName][0] // Get the first entry for comparison
+			match := serviceMap[svc.Name][0] // Get the first entry for comparison
 
 			// Build up a sorted list of ServicePorts from the existing service
 			portsToMatch := getSortedServicePorts(match)
@@ -226,13 +224,13 @@ func servicesWithPorts(state *catalog.ServicesState) map[string][]*service.Servi
 					// TODO should we just add another service with this port added
 					// to the name? We have to find out which port.
 					log.Warnf("%s service from %s not added: non-matching ports! (%v vs %v)",
-						state.ServiceName(svc), svc.Hostname, port, portsWeHave[i])
+						svc.Name, svc.Hostname, port, portsWeHave[i])
 					return
 				}
 			}
 
 			// It was a match! Append to the list.
-			serviceMap[svcName] = append(serviceMap[svcName], svc)
+			serviceMap[svc.Name] = append(serviceMap[svc.Name], svc)
 		},
 	)
 

--- a/haproxy/haproxy_test.go
+++ b/haproxy/haproxy_test.go
@@ -34,7 +34,7 @@ func Test_HAproxy(t *testing.T) {
 		services := []service.Service{
 			service.Service{
 				ID:          svcId1,
-				Name:        "awesome-svc-adfffed1233",
+				Name:        "awesome-svc",
 				Image:       "awesome-svc",
 				Hostname:    hostname1,
 				Updated:     baseTime.Add(5 * time.Second),
@@ -43,7 +43,7 @@ func Test_HAproxy(t *testing.T) {
 			},
 			service.Service{
 				ID:          svcId2,
-				Name:        "awesome-svc-1234fed1233",
+				Name:        "awesome-svc",
 				Image:       "awesome-svc",
 				Hostname:    hostname2,
 				Updated:     baseTime.Add(5 * time.Second),
@@ -52,7 +52,7 @@ func Test_HAproxy(t *testing.T) {
 			},
 			service.Service{
 				ID:          svcId3,
-				Name:        "some-svc-0123456789a",
+				Name:        "some-svc",
 				Image:       "some-svc",
 				Hostname:    hostname2,
 				Updated:     baseTime.Add(5 * time.Second),
@@ -61,7 +61,7 @@ func Test_HAproxy(t *testing.T) {
 			},
 			service.Service{
 				ID:          svcId4,
-				Name:        "some-svc-befede6789a",
+				Name:        "some-svc",
 				Image:       "some-svc",
 				Hostname:    hostname2,
 				Updated:     baseTime.Add(5 * time.Second),
@@ -105,23 +105,22 @@ func Test_HAproxy(t *testing.T) {
 		Convey("servicesWithPorts() groups services by name and port", func() {
 			badSvc := service.Service{
 				ID:       "0000bad00000",
-				Name:     "some-svc-0155555789a",
+				Name:     "some-svc",
 				Image:    "some-svc",
 				Hostname: "titanic",
 				Updated:  baseTime.Add(5 * time.Second),
 				Ports:    []service.Port{service.Port{"tcp", 666, 6666}},
 			}
 
-			svcName := state.ServiceName(&badSvc)
 			// It had 1 before
 			svcList := servicesWithPorts(state)
-			So(len(svcList[svcName]), ShouldEqual, 1)
+			So(len(svcList[badSvc.Name]), ShouldEqual, 1)
 
 			// We add an entry with mismatching ports and should get no more added
 			state.AddServiceEntry(badSvc)
 
 			svcList = servicesWithPorts(state)
-			So(len(svcList[svcName]), ShouldEqual, 1)
+			So(len(svcList[badSvc.Name]), ShouldEqual, 1)
 		})
 
 		Convey("WriteConfig() writes a template from a file", func() {

--- a/healthy/healthy.go
+++ b/healthy/healthy.go
@@ -37,7 +37,6 @@ type Monitor struct {
 	CheckInterval        time.Duration
 	DefaultCheckHost     string
 	DiscoveryFn          func() []service.Service
-	ServiceNameFn        func(*service.Service) string
 	DefaultCheckEndpoint string
 	sync.RWMutex
 }

--- a/sidecar.example.toml
+++ b/sidecar.example.toml
@@ -13,7 +13,9 @@ docker_url = "unix://var/run/docker.sock"
 config_file = "static.json"
 
 [services]
-name_match = "^/(.+)(-[0-9a-z]{7,14})$"
+namer = "regexp" # or "regex"
+#name_match = "^/(.+)(-[0-9a-z]{7,14})$" # Only used when namer = "regex"
+name_label = "ServiceName"
 
 [haproxy]
 # bind_ip is optional. Default is the frst interface with

--- a/sidecar.go
+++ b/sidecar.go
@@ -70,6 +70,13 @@ func configureDiscovery(config *Config) discovery.Discoverer {
 	disco := new(discovery.MultiDiscovery)
 
 	var svcNamer discovery.ServiceNamer
+	var usingDocker bool
+
+	for _, method := range config.Sidecar.Discovery {
+		if method == "docker" {
+			usingDocker = true
+		}
+	}
 
 	switch config.Services.ServiceNamer {
 	case "docker_label":
@@ -81,7 +88,9 @@ func configureDiscovery(config *Config) discovery.Discoverer {
 			ServiceNameMatch: config.Services.NameMatch,
 		}
 	default:
-		log.Fatalf("Unable to configure service namer! Not a valid entry.")
+		if usingDocker {
+			log.Fatalf("Unable to configure service namer! Not a valid entry.")
+		}
 	}
 
 	for _, method := range config.Sidecar.Discovery {


### PR DESCRIPTION
Based on the ideas from @actaeon in #9. The idea is to be very flexible and extensible about how services are named when discovered in Docker. We originally supported only using a regex match on the service name. Now we also support a Docker label.

**Note:** this is a breaking change in that it requires a `namer =` setting in the `[services]` section of the config. Existing implementations willl need to add `namer = "regex"`.

@actaeon I think this does what you wanted, in the way I had suggested in your other PR. Let me know.