### PR TITLE
Encode/Decode the whole state struct

### DIFF
--- a/discovery/service_namer_test.go
+++ b/discovery/service_namer_test.go
@@ -18,7 +18,7 @@ func Test_RegexpNamer(t *testing.T) {
 
 		var namer ServiceNamer
 
-		Convey("Properly extracts a ServiceName", func() {
+		Convey("Extracts a ServiceName", func() {
 			namer = &RegexpNamer{ ServiceNameMatch: "^/(.+)(-[0-9a-z]{7,14})$" }
 			So(namer.ServiceName(container), ShouldEqual, "awesome-svc")
 		})
@@ -26,6 +26,11 @@ func Test_RegexpNamer(t *testing.T) {
 		Convey("Returns the image when the expression doesn't match", func() {
 			namer = &RegexpNamer{ ServiceNameMatch: "ASDF" }
 			So(namer.ServiceName(container), ShouldEqual, "gonitro/awesome-svc:0.1.34")
+		})
+
+		Convey("Handles error when passed a nil service", func() {
+			namer = &RegexpNamer{}
+			So(namer.ServiceName(nil), ShouldEqual, "")
 		})
 	})
 }
@@ -41,7 +46,7 @@ func Test_DockerLabelNamer(t *testing.T) {
 
 		var namer ServiceNamer
 
-		Convey("Properly extracts a ServiceName", func() {
+		Convey("Extracts a ServiceName", func() {
 			namer = &DockerLabelNamer{ Label: "ServiceName" }
 			So(namer.ServiceName(container), ShouldEqual, "awesome-svc-1")
 		})
@@ -49,6 +54,11 @@ func Test_DockerLabelNamer(t *testing.T) {
 		Convey("Returns the image when the expression doesn't match", func() {
 			namer = &DockerLabelNamer{ Label: "ASDF" }
 			So(namer.ServiceName(container), ShouldEqual, "gonitro/awesome-svc:0.1.34")
+		})
+
+		Convey("Handles error when passed a nil service", func() {
+			namer = &DockerLabelNamer{}
+			So(namer.ServiceName(nil), ShouldEqual, "")
 		})
 	})
 }


### PR DESCRIPTION
We were only every passing around the `Servers` from a state struct. This now also passes `LastChanged` which is useful for anyone with a listener (e.g. `haproxy-api` or anyone on the `/watch` endpoint. The comments added for the struct now block JSON from encoding or decoding the other fields.

currently based against #15 

cc @actaeon 