### PR TITLE
Fix template when using dynamic port assignment

### DIFF
--- a/haproxy/haproxy_test.go
+++ b/haproxy/haproxy_test.go
@@ -30,41 +30,42 @@ func Test_HAproxy(t *testing.T) {
 
 		ports1 := []service.Port{service.Port{"tcp", 10450, 8080}, service.Port{"tcp", 10020, 9000}}
 		ports2 := []service.Port{service.Port{"tcp", 9999, 8090}}
+		ports3 := []service.Port{service.Port{"tcp", 32763, 8080}, service.Port{"tcp", 10020, 9000}}
 
 		services := []service.Service{
 			service.Service{
-				ID:          svcId1,
-				Name:        "awesome-svc",
-				Image:       "awesome-svc",
-				Hostname:    hostname1,
-				Updated:     baseTime.Add(5 * time.Second),
+				ID:        svcId1,
+				Name:      "awesome-svc",
+				Image:     "awesome-svc",
+				Hostname:  hostname1,
+				Updated:   baseTime.Add(5 * time.Second),
 				ProxyMode: "http",
-				Ports:       ports1,
+				Ports:     ports1,
 			},
 			service.Service{
-				ID:          svcId2,
-				Name:        "awesome-svc",
-				Image:       "awesome-svc",
-				Hostname:    hostname2,
-				Updated:     baseTime.Add(5 * time.Second),
+				ID:        svcId2,
+				Name:      "awesome-svc",
+				Image:     "awesome-svc",
+				Hostname:  hostname2,
+				Updated:   baseTime.Add(5 * time.Second),
 				ProxyMode: "http",
-				Ports:       ports1,
+				Ports:     ports3,
 			},
 			service.Service{
-				ID:          svcId3,
-				Name:        "some-svc",
-				Image:       "some-svc",
-				Hostname:    hostname2,
-				Updated:     baseTime.Add(5 * time.Second),
+				ID:        svcId3,
+				Name:      "some-svc",
+				Image:     "some-svc",
+				Hostname:  hostname2,
+				Updated:   baseTime.Add(5 * time.Second),
 				ProxyMode: "tcp",
-				Ports:       ports2,
+				Ports:     ports2,
 			},
 			service.Service{
-				ID:          svcId4,
-				Name:        "some-svc",
-				Image:       "some-svc",
-				Hostname:    hostname2,
-				Updated:     baseTime.Add(5 * time.Second),
+				ID:        svcId4,
+				Name:      "some-svc",
+				Image:     "some-svc",
+				Hostname:  hostname2,
+				Updated:   baseTime.Add(5 * time.Second),
 				ProxyMode: "tcp",
 				// No ports!
 			},
@@ -133,6 +134,7 @@ func Test_HAproxy(t *testing.T) {
 			So(output, ShouldMatch, "frontend awesome-svc-8080")
 			So(output, ShouldMatch, "backend awesome-svc-8080")
 			So(output, ShouldMatch, "server.*indefatigable:10020")
+			So(output, ShouldMatch, "server.*indefatigable:32763")
 			So(output, ShouldMatch, "bind 192.168.168.168:9000")
 			So(output, ShouldMatch, "frontend some-svc-8090")
 			So(output, ShouldMatch, "backend some-svc-8090")

--- a/views/haproxy.cfg
+++ b/views/haproxy.cfg
@@ -54,7 +54,7 @@ frontend {{ sanitizeName $svcName }}-{{ $svcPort }}
 	default_backend {{ sanitizeName $svcName }}-{{ $svcPort }}
 
 backend {{ sanitizeName $svcName }}-{{ $svcPort }}
-	mode {{ getMode $svcName }} {{ range $services }}
-	server {{ .Hostname }}-{{ .ID }} {{ .Hostname }}:{{ $port }} cookie {{ .Hostname }}-{{ $port }} {{ end }}
+	mode {{ getMode $svcName }} {{ range $svc := $services }}
+	server {{ $svc.Hostname }}-{{ $svc.ID }} {{ $svc.Hostname }}:{{ portFor $svcPort $svc }} cookie {{ $svc.Hostname }}-{{ portFor $svcPort $svc }} {{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
This fixes the templating when using dynamically assigned backed ports. This added function will allow you to look up the port for this service that matches the current `ServicePort`. Modifies the test to make sure we're actually testing this behavior as well. This is backward compatible.

sidekick @benoahriz