### PR TITLE
Bindip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docker/views
 bower_components
 node_modules
 npm-debug.log
+.idea/

--- a/docker/s6/services/sidecar.svc/run
+++ b/docker/s6/services/sidecar.svc/run
@@ -17,12 +17,17 @@ if [[ -n "$SIDECAR_LISTENER" ]]; then
 	sed -i.bak 's~^urls *= *\[~urls = \[ "'"$SIDECAR_LISTENER"'", ~' sidecar.toml
 fi
 
+# Update the bind_ip if set as an env var to override the original
+if [[ -n "$BIND_IP" ]]; then
+	sed -i.bak 's~^bind_ip *=.*$~bind_ip = "'"$BIND_IP"'"~' sidecar.toml
+fi
+
 BIND_IP=`grep bind_ip sidecar.toml | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*"`
 
 # If there's a BIND_IP and we don't already have it, add the
 # address to the loopback interface.
 if [[ -n "$BIND_IP" ]] && [[ $BIND_IP != "0.0.0.0" ]]; then
- 	ip addr show | grep $BIND_IP 
+ 	ip addr show | grep $BIND_IP
 	if [[ $? -ne 0 ]]; then
 		echo "Adding $BIND_IP to the loopback interface"
 		ip addr add $BIND_IP/32 dev lo


### PR DESCRIPTION
Added the ability to ingest the BIND_IP env var into the startup script.  This allows the use of 
docker-compose on osx using BIND_IP=0.0.0.0 so that haproxy can be exposed when hitting localhost on osx.  Tested this locally and seems to support both use cases localtesting and on linux servers needing to use 192.168.168.168

``` yaml
  sidecar:
    hostname: osx
    image: sidecar:latest
    cap_add:
      - NET_ADMIN
    labels:
      SidecarDiscover: "false"
    environment:
      - "BIND_IP=0.0.0.0"
      - "SIDECAR_LOGGING_LEVEL=debug"
      - "SIDECAR_SEEDS=127.0.0.1"
      - "SIDECAR_CLUSTER_NAME=development"
      - "SIDECAR_DISCOVERY=docker static"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - ./static-services.json:/sidecar/static.json
    ports:
      - 10000-10050:10000-10050
      - 1777:7777
      - 3212:3212
```