### PR TITLE
Add decoder to stream from /watch endpoint

### DIFF
--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -540,13 +540,13 @@ func Test_DecodeStream(t *testing.T) {
 		}
 
 		var compareMap map[string][]*service.Service
-		MockCallback := func(sidecarStates map[string][]*service.Service, err error) error {
+		mockCallback := func(sidecarStates map[string][]*service.Service, err error) error {
 			compareMap = sidecarStates
 			return nil
 		}
 
 		buf := bytes.NewBufferString(string(jsonBytes))
-		err = DecodeStream(buf, MockCallback)
+		err = DecodeStream(buf, mockCallback)
 		So(err, ShouldBeNil)
 		So(compareMap["api"][0].Hostname, ShouldEqual, "some-aws-host")
 		So(compareMap["api"][0].Status, ShouldEqual, 1)

--- a/http.go
+++ b/http.go
@@ -10,12 +10,12 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
-	"github.com/gorilla/mux"
+	"github.com/Nitro/memberlist"
 	"github.com/Nitro/sidecar/catalog"
 	"github.com/Nitro/sidecar/output"
 	"github.com/Nitro/sidecar/service"
-	"github.com/Nitro/memberlist"
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
 )
 
 type ApiServer struct {
@@ -70,12 +70,11 @@ func watchHandler(response http.ResponseWriter, req *http.Request, list *memberl
 			// In order to flush immediately, we have to cast to a Flusher.
 			// The normal HTTP library supports this but not all do, so we
 			// check just in case.
+			response.Write(jsonBytes)
 			if f, ok := response.(http.Flusher); ok {
 				f.Flush()
 			}
-			response.Write(jsonBytes)
 		}
-
 		time.Sleep(250 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
Add DecodeStream to catalog package for consuming stream from watchHandler.  This will decode the map of service.Service objects (returned by the watchHandler) then call the callback function.

Update watchHandler to first write the response, then flush.  This will address a noted issue where the consumer (DecodeStream in this case) won't finish decoding the current object until a new one enters the array.

Add unit test for DecodeStream

