### PR TITLE
Convert /watch to Listener & don't leak goroutines

### DIFF
--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -230,6 +230,23 @@ func (state *ServicesState) AddListener(listener Listener) {
 	log.Debugf("AddListener(): added %s, new count %d", listener.Name(), len(state.listeners))
 }
 
+// Remove an event listener channel by name. This will find the first
+// listener in the list with the specified name and will remove it.
+func (state *ServicesState) RemoveListener(name string) error {
+	state.Lock()
+	defer state.Unlock()
+
+	for i := 0; i < len(state.listeners); i++ {
+		if state.listeners[i].Name() == name {
+			state.listeners = append(state.listeners[:i], state.listeners[i+1:]...)
+			log.Debugf("RemoveListener(): removed %s, new count %d", name, len(state.listeners))
+			return nil
+		}
+	}
+
+	return fmt.Errorf("No listener found with the name: %s", name)
+}
+
 // Take a service and merge it into our state. Correctly handle
 // timestamps so we only add things newer than what we already
 // know about. Retransmits updates to cluster peers.

--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -461,6 +461,20 @@ func Test_Listeners(t *testing.T) {
 			So(len(state.listeners), ShouldEqual, 1)
 		})
 
+		Convey("Removing listeners results in them being removed from the list", func() {
+			state.AddListener(listener)
+			So(len(state.listeners), ShouldEqual, 1)
+
+			err := state.RemoveListener("listener1")
+			So(len(state.listeners), ShouldEqual, 0)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Removing a listener that doesn't exist returns an error", func() {
+			err := state.RemoveListener("foo")
+			So(err, ShouldNotBeNil)
+		})
+
 		Convey("A major state change event notifies all listeners", func() {
 			var result ChangeEvent
 			var result2 ChangeEvent

--- a/http.go
+++ b/http.go
@@ -30,7 +30,7 @@ type ApiServices struct {
 	ClusterName    string
 }
 
-// A ServicesState.Listener that we use for the /watch endpoitn
+// A ServicesState.Listener that we use for the /watch endpoint
 type HttpListener struct {
 	eventChan chan catalog.ChangeEvent
 	name      string
@@ -38,7 +38,7 @@ type HttpListener struct {
 
 func NewHttpListener() *HttpListener {
 	return &HttpListener{
-		// This should be fine enough granularity for practical purpoes
+		// This should be fine enough granularity for practical purposes
 		name: fmt.Sprintf("httpListener-%d", time.Now().UTC().UnixNano()),
 		// Listeners must have buffered channels. We'll use a
 		// somewhat larger buffer here because of the slow link


### PR DESCRIPTION
This address the same issue as https://github.com/newrelic/sidecar/pull/26 but fixes it by also converting the `/watch` endpoint to use the state listener mechanism so that it's not different from all the other places in the code that receive updates. Should be much more efficient and updates will be delivered faster, too.

sidekick @bparli @felixgborrego