### PR TITLE
Explicit return from watchHandler

### DIFF
--- a/http.go
+++ b/http.go
@@ -84,7 +84,7 @@ func watchHandler(response http.ResponseWriter, req *http.Request, list *memberl
 	for {
 		select {
 		case <-notify:
-			break
+			return
 
 		case <-listener.Chan():
 			jsonBytes, err = json.Marshal(state.ByService())


### PR DESCRIPTION
Instead of breaking, return when the HTTP client closes.  