### PR TITLE
remove error return value from callback

### DIFF
--- a/catalog/services_state.go
+++ b/catalog/services_state.go
@@ -594,7 +594,7 @@ func (state *ServicesState) ByService() map[string][]*service.Service {
 	return serviceMap
 }
 
-func DecodeStream(input io.Reader, callback func(map[string][]*service.Service, error) error) error {
+func DecodeStream(input io.Reader, callback func(map[string][]*service.Service, error)) error {
 	dec := json.NewDecoder(input)
 	for dec.More() {
 		var conf map[string][]*service.Service

--- a/catalog/services_state_test.go
+++ b/catalog/services_state_test.go
@@ -560,8 +560,7 @@ func Test_DecodeStream(t *testing.T) {
 		}
 
 		buf := bytes.NewBufferString(string(jsonBytes))
-		err = DecodeStream(buf, mockCallback)
-		So(err, ShouldBeNil)
+		DecodeStream(buf, mockCallback)
 		So(compareMap["api"][0].Hostname, ShouldEqual, "some-aws-host")
 		So(compareMap["api"][0].Status, ShouldEqual, 1)
 	})


### PR DESCRIPTION
We don't need or use the error value returned by callback so remove it

ping @relistan 