### PR TITLE
Adds a configuration setting to force the old haproxy.cfg behavior

### DIFF
--- a/config.go
+++ b/config.go
@@ -20,6 +20,7 @@ type HAproxyConfig struct {
 	Disable      bool   `toml:"disable"`
 	User         string `toml:"user"`
 	Group        string `toml:"group"`
+	UseHostnames bool   `toml:"use_hostnames"`
 }
 
 type ServicesConfig struct {

--- a/docker/s6/services/sidecar.svc/run
+++ b/docker/s6/services/sidecar.svc/run
@@ -22,6 +22,11 @@ if [[ -n "$BIND_IP" ]]; then
 	sed -i.bak 's~^bind_ip *=.*$~bind_ip = "'"$BIND_IP"'"~' sidecar.toml
 fi
 
+# If we're disabling IP addresses in the HAproxy configs
+if [[ -n "$USE_HOSTNAMES" ]]; then
+	sed -i.bak 's~^use_hostnames *=.*$~use_hostnames = "'"$USE_HOSTNAMES"'"~' sidecar.toml
+fi
+
 BIND_IP=`grep bind_ip sidecar.toml | grep -o "[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*"`
 
 # If there's a BIND_IP and we don't already have it, add the

--- a/docker/sidecar.docker.toml
+++ b/docker/sidecar.docker.toml
@@ -20,6 +20,7 @@ config_file   = "/etc/haproxy.cfg"
 pid_file      = "/var/run/haproxy.pid"
 user          = "haproxy"
 group         = "haproxy"
+use_hostnames = false
 
 [listeners]
 urls = [ "http://192.168.168.168:7778/update" ]

--- a/haproxy/haproxy_test.go
+++ b/haproxy/haproxy_test.go
@@ -105,6 +105,22 @@ func Test_HAproxy(t *testing.T) {
 			So(result["some-svc"], ShouldEqual, "tcp")
 		})
 
+		Convey("findIpForService() returns hostnames when UseHostnames is set", func() {
+			proxy.UseHostnames = true
+			svc := services[0]
+			result := proxy.findIpForService("8080", &svc)
+
+			So(result, ShouldEqual, "indomitable")
+		})
+
+		Convey("findIpForService() returns IP addresses when UseHostnames is false", func() {
+			proxy.UseHostnames = false
+			svc := services[0]
+			result := proxy.findIpForService("8080", &svc)
+
+			So(result, ShouldEqual, "127.0.0.1")
+		})
+
 		Convey("servicesWithPorts() groups services by name and port", func() {
 			badSvc := service.Service{
 				ID:       "0000bad00000",
@@ -192,11 +208,11 @@ func Test_HAproxy(t *testing.T) {
 		Convey("Reload() returns an error when it fails", func() {
 			proxy.ReloadCmd = "sh -c 'exit 1'"
 			err := proxy.Reload()
-			So(err.Error(), ShouldEqual, "exit status 1")
+			So(err.Error(), ShouldContainSubstring, "exit status 1")
 
 			proxy.ReloadCmd = "yomomma"
 			err = proxy.Reload()
-			So(err.Error(), ShouldEqual, "exit status 127")
+			So(err.Error(), ShouldContainSubstring, "exit status 127")
 		})
 
 		Convey("WriteAndReload() bubbles up errors on failure", func() {

--- a/main.go
+++ b/main.go
@@ -65,6 +65,8 @@ func configureHAproxy(config Config) *haproxy.HAproxy {
 		proxy.Group = config.HAproxy.Group
 	}
 
+	proxy.UseHostnames = config.HAproxy.UseHostnames
+
 	return proxy
 }
 

--- a/sidecar.example.toml
+++ b/sidecar.example.toml
@@ -48,6 +48,12 @@ template_file = "views/haproxy.cfg"
 config_file   = "/etc/haproxy.cfg"
 pid_file      = "/var/run/haproxy.pid"
 
+# This setting will force HAproxy configs to be written
+# using hostnames rather than IP addresses. This can be
+# required when using Docker for Mac, for example, or
+# in a situation where there is some address remapping.
+use_hostnames = false
+
 # URLs can be subscribed to Sidecar state change events.
 # Each URL in the list will be posted to with a copy
 # of the event, which contains the service that changed


### PR DESCRIPTION
This adds a setting that will force haproxy configuration to be written without using the new IP address information. This can solve problems with Docker for Mac or anywhere where the Docker binding IP address is getting remapped to another address on the outside.

@felixgborrego