### PR TITLE
Stop blowing up UI on missing HAproxy

### DIFF
--- a/ui/app/services/services.js
+++ b/ui/app/services/services.js
@@ -127,7 +127,7 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 		try {
 			raw = Papa.parse(haproxyResponse, { header: true });
 		} catch(e) {
-			console.log("Appears there is HAproxy, skipping")
+			console.log("Appears there is no HAproxy, skipping")
 			return;
 		}
 

--- a/ui/app/services/services.js
+++ b/ui/app/services/services.js
@@ -27,6 +27,7 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 			method: 'GET',
 			url: haproxyUrl,
 			dataType: 'text/plain',
+			timeout: 300
 		});
 	};
 
@@ -122,7 +123,13 @@ angular.module('sidecar.services', ['ngRoute', 'ui.bootstrap'])
 
 		// Haproxy
 		var haproxyResponse = stateService.getHaproxy();
-		var raw = Papa.parse(haproxyResponse, { header: true });
+		var raw = {};
+		try {
+			raw = Papa.parse(haproxyResponse, { header: true });
+		} catch(e) {
+			console.log("Appears there is HAproxy, skipping")
+			return;
+		}
 
 		var transform = function(memo, item) {
 			if (item.svname == 'FRONTEND' || item.svname == 'BACKEND' ||


### PR DESCRIPTION
This is not the best fix, but it works around the issue with HAproxy not being installed on machines running Envoy. This will speed up first load of the UI a **LOT** because it also implements a timeout on that call. It then catches any error from the CSV parse (`Papa.parse()`) and then simply returns from the method.

*Ideally* Sidecar would export a config endpoint and the UI would call it to determine if HAproxy is even needed. This implementation is still a hack, but it's a lot better than before.