### PR TITLE
Allow more Memberlist configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,8 @@ type SidecarConfig struct {
 	StatsAddr            string        `envconfig:"STATS_ADDR"`
 	PushPullInterval     time.Duration `envconfig:"PUSH_PULL_INTERVAL" default:"20s"`
 	GossipMessages       int           `envconfig:"GOSSIP_MESSAGES" default:"15"`
-	GossipInterval		 time.Duration `envconfig:"GOSSUP_INTERVAL" default:"200ms"`
+	GossipInterval		 time.Duration `envconfig:"GOSSIP_INTERVAL" default:"200ms"`
+	HandoffQueueDepth    int           `envconfig:"HANDOFF_QUEUE_DEPTH" default:"1024"`
 	LoggingFormat        string        `envconfig:"LOGGING_FORMAT"`
 	LoggingLevel         string        `envconfig:"LOGGING_LEVEL" default:"info"`
 	DefaultCheckEndpoint string        `envconfig:"DEFAULT_CHECK_ENDPOINT" default:"/version"`

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type SidecarConfig struct {
 	StatsAddr            string        `envconfig:"STATS_ADDR"`
 	PushPullInterval     time.Duration `envconfig:"PUSH_PULL_INTERVAL" default:"20s"`
 	GossipMessages       int           `envconfig:"GOSSIP_MESSAGES" default:"15"`
+	GossipInterval		 time.Duration `envconfig:"GOSSUP_INTERVAL" default:"200ms"`
 	LoggingFormat        string        `envconfig:"LOGGING_FORMAT"`
 	LoggingLevel         string        `envconfig:"LOGGING_LEVEL" default:"info"`
 	DefaultCheckEndpoint string        `envconfig:"DEFAULT_CHECK_ENDPOINT" default:"/version"`

--- a/main.go
+++ b/main.go
@@ -247,6 +247,7 @@ func configureMemberlist(config *config.Config, state *catalog.ServicesState) *m
 	if config.Sidecar.GossipMessages != 0 {
 		mlConfig.GossipMessages = config.Sidecar.GossipMessages
 	}
+	mlConfig.GossipInterval = config.Sidecar.GossipInterval
 
 	// Make sure we pass on the cluster name to Memberlist
 	mlConfig.ClusterName = config.Sidecar.ClusterName

--- a/main.go
+++ b/main.go
@@ -248,6 +248,7 @@ func configureMemberlist(config *config.Config, state *catalog.ServicesState) *m
 		mlConfig.GossipMessages = config.Sidecar.GossipMessages
 	}
 	mlConfig.GossipInterval = config.Sidecar.GossipInterval
+	mlConfig.HandoffQueueDepth = config.Sidecar.HandoffQueueDepth
 
 	// Make sure we pass on the cluster name to Memberlist
 	mlConfig.ClusterName = config.Sidecar.ClusterName


### PR DESCRIPTION
We need to be able to configure more items in the memberlist config. This allows changing both the handoff buffer size and the gossip interval.