### PR TITLE
K8s API-based Discovery

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,20 +39,22 @@ type ServicesConfig struct {
 }
 
 type SidecarConfig struct {
-	ExcludeIPs           []string      `envconfig:"EXCLUDE_IPS" default:"192.168.168.168"`
-	Discovery            []string      `envconfig:"DISCOVERY" default:"docker"`
-	StatsAddr            string        `envconfig:"STATS_ADDR"`
-	PushPullInterval     time.Duration `envconfig:"PUSH_PULL_INTERVAL" default:"20s"`
-	GossipMessages       int           `envconfig:"GOSSIP_MESSAGES" default:"15"`
-	GossipInterval       time.Duration `envconfig:"GOSSIP_INTERVAL" default:"200ms"`
-	HandoffQueueDepth    int           `envconfig:"HANDOFF_QUEUE_DEPTH" default:"1024"`
-	LoggingFormat        string        `envconfig:"LOGGING_FORMAT"`
-	LoggingLevel         string        `envconfig:"LOGGING_LEVEL" default:"info"`
-	DefaultCheckEndpoint string        `envconfig:"DEFAULT_CHECK_ENDPOINT" default:"/version"`
-	Seeds                []string      `envconfig:"SEEDS"`
-	ClusterName          string        `envconfig:"CLUSTER_NAME" default:"default"`
-	AdvertiseIP          string        `envconfig:"ADVERTISE_IP"`
-	BindPort             int           `envconfig:"BIND_PORT" default:"7946"`
+	ExcludeIPs             []string      `envconfig:"EXCLUDE_IPS" default:"192.168.168.168"`
+	Discovery              []string      `envconfig:"DISCOVERY" default:"docker"`
+	StatsAddr              string        `envconfig:"STATS_ADDR"`
+	PushPullInterval       time.Duration `envconfig:"PUSH_PULL_INTERVAL" default:"20s"`
+	GossipMessages         int           `envconfig:"GOSSIP_MESSAGES" default:"15"`
+	GossipInterval         time.Duration `envconfig:"GOSSIP_INTERVAL" default:"200ms"`
+	HandoffQueueDepth      int           `envconfig:"HANDOFF_QUEUE_DEPTH" default:"1024"`
+	LoggingFormat          string        `envconfig:"LOGGING_FORMAT"`
+	LoggingLevel           string        `envconfig:"LOGGING_LEVEL" default:"info"`
+	DefaultCheckEndpoint   string        `envconfig:"DEFAULT_CHECK_ENDPOINT" default:"/version"`
+	Seeds                  []string      `envconfig:"SEEDS"`
+	ClusterName            string        `envconfig:"CLUSTER_NAME" default:"default"`
+	AdvertiseIP            string        `envconfig:"ADVERTISE_IP"`
+	BindPort               int           `envconfig:"BIND_PORT" default:"7946"`
+	Debug                  bool          `envconfig:"DEBUG" default:"false"`
+	DiscoverySleepInterval time.Duration `envconfig:"DISCOVERY_SLEEP_INTERVAL" default:"1s"`
 }
 
 type DockerConfig struct {
@@ -63,10 +65,18 @@ type StaticConfig struct {
 	ConfigFile string `envconfig:"CONFIG_FILE" default:"static.json"`
 }
 
+type K8sAPIConfig struct {
+	ClusterIP       string `envconfig:"CLUSTER_IP" default:"127.0.0.1"`
+	ClusterHostname string `envconfig:"CLUSTER_HOSTNAME" default:"localhost"`
+	Namespace       string `envconfig:"NAMESPACE" default:"default"`
+	KubectlPath     string `envconfig:"KUBECTL_PATH" default:"/usr/local/bin/kubectl"`
+}
+
 type Config struct {
 	Sidecar         SidecarConfig      // SIDECAR_
 	DockerDiscovery DockerConfig       // DOCKER_
 	StaticDiscovery StaticConfig       // STATIC_
+	K8sAPIDiscovery K8sAPIConfig       // K8S_
 	Services        ServicesConfig     // SERVICES_
 	HAproxy         HAproxyConfig      // HAPROXY_
 	Envoy           EnvoyConfig        // ENVOY_
@@ -80,6 +90,7 @@ func ParseConfig() *Config {
 		envconfig.Process("sidecar", &config.Sidecar),
 		envconfig.Process("docker", &config.DockerDiscovery),
 		envconfig.Process("static", &config.StaticDiscovery),
+		envconfig.Process("k8s", &config.K8sAPIDiscovery),
 		envconfig.Process("services", &config.Services),
 		envconfig.Process("haproxy", &config.HAproxy),
 		envconfig.Process("envoy", &config.Envoy),

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,8 @@ type SidecarConfig struct {
 	StatsAddr            string        `envconfig:"STATS_ADDR"`
 	PushPullInterval     time.Duration `envconfig:"PUSH_PULL_INTERVAL" default:"20s"`
 	GossipMessages       int           `envconfig:"GOSSIP_MESSAGES" default:"15"`
+	GossipInterval       time.Duration `envconfig:"GOSSIP_INTERVAL" default:"200ms"`
+	HandoffQueueDepth    int           `envconfig:"HANDOFF_QUEUE_DEPTH" default:"1024"`
 	LoggingFormat        string        `envconfig:"LOGGING_FORMAT"`
 	LoggingLevel         string        `envconfig:"LOGGING_LEVEL" default:"info"`
 	DefaultCheckEndpoint string        `envconfig:"DEFAULT_CHECK_ENDPOINT" default:"/version"`

--- a/discovery/kubernetes_api_discovery.go
+++ b/discovery/kubernetes_api_discovery.go
@@ -1,0 +1,98 @@
+package discovery
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/NinesStack/sidecar/service"
+	"github.com/relistan/go-director"
+	log "github.com/sirupsen/logrus"
+)
+
+// A K8sAPIDiscoverer is a discovery mechanism that assumes that a K8s cluster
+// with be fronted by a load balancer and that all the ports exposed will match
+// up on both the load balancer and the backing pods. It relies on an underlying
+// command to run the discovery. This is normally `kubectl`.
+type K8sAPIDiscoverer struct {
+	ClusterIP       string
+	ClusterHostname string
+	Namespace       string
+
+	Command K8sDiscoveryCommand
+
+	discovered *K8sServices
+}
+
+// NewK8sAPIDiscoverer returns a properly configured K8sAPIDiscoverer
+func NewK8sAPIDiscoverer(clusterIP, clusterHostname, namespace, path string) *K8sAPIDiscoverer {
+	return &K8sAPIDiscoverer{
+		discovered:      &K8sServices{},
+		ClusterIP:       clusterIP,
+		ClusterHostname: clusterHostname,
+		Namespace:       namespace,
+		Command: &KubectlDiscoveryCommand{
+			Path:      path,
+			Namespace: namespace,
+		},
+	}
+}
+
+// Services implements part of the Discoverer interface and looks at the last
+// cached data from the Command (`kubectl`) and returns services in a format
+// that Sidecar can manage.
+func (k *K8sAPIDiscoverer) Services() []service.Service {
+	var services []service.Service
+	for _, item := range k.discovered.Items {
+		svc := service.Service{
+			ID:        item.Metadata.UID,
+			Name:      item.Metadata.Labels.ServiceName,
+			Image:     item.Metadata.Labels.ServiceName+":kubernetes-hosted",
+			Created:   item.Metadata.CreationTimestamp,
+			Hostname:  k.ClusterHostname,
+			ProxyMode: "http",
+			Status:    service.ALIVE,
+			Updated:   time.Now().UTC(),
+		}
+		for _, port := range item.Spec.Ports {
+			svc.Ports = append(svc.Ports, service.Port{
+				Type:        "tcp",
+				Port:        int64(port.Port),
+				ServicePort: int64(port.Port),
+				IP:          k.ClusterIP,
+			})
+		}
+		services = append(services, svc)
+	}
+
+	return services
+}
+
+// HealthCheck implements part of the Discoverer interface and returns the
+// built-in AlwaysSuccessful check, on the assumption that the underlying load
+// balancer we are pointing to will have already health checked the service.
+func (k *K8sAPIDiscoverer) HealthCheck(svc *service.Service) (string, string) {
+	return "AlwaysSuccessful", ""
+}
+
+// Listeners implements part of the Discoverer interface and always returns
+// an empty list because it doesn't make sense in this context.
+func (k *K8sAPIDiscoverer) Listeners() []ChangeListener {
+	return []ChangeListener{}
+}
+
+// Run is part of the Discoverer interface and calls the Command in a loop,
+// which is injected as a Looper.
+func (k *K8sAPIDiscoverer) Run(looper director.Looper) {
+	looper.Loop(func() error {
+		data, err := k.Command.Run()
+		if err != nil {
+			log.Errorf("Failed to invoke K8s API discovery: %s", err)
+		}
+
+		err = json.Unmarshal(data, &k.discovered)
+		if err != nil {
+			log.Errorf("Failed to unmarshal json: %s, %s", err, string(data))
+		}
+		return nil
+	})
+}

--- a/discovery/kubernetes_api_discovery_test.go
+++ b/discovery/kubernetes_api_discovery_test.go
@@ -1,0 +1,166 @@
+package discovery
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/NinesStack/sidecar/service"
+	"github.com/relistan/go-director"
+	log "github.com/sirupsen/logrus"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type mockK8sDiscoveryCommand struct {
+	RunShouldError      bool
+	RunShouldReturnJunk bool
+	WasCalled           bool
+}
+
+func (m *mockK8sDiscoveryCommand) Run() ([]byte, error) {
+	m.WasCalled = true
+
+	if m.RunShouldError {
+		return nil, errors.New("intentional test error")
+	}
+
+	if m.RunShouldReturnJunk {
+		return []byte(`asdfasdf`), nil
+	}
+
+	jsonStr := `
+	{
+	   "items" : [
+	      {
+	         "metadata" : {
+	            "creationTimestamp" : "2022-11-07T13:18:03Z",
+	            "labels" : {
+	               "Environment" : "dev",
+	               "ServiceName" : "chopper"
+	            },
+	            "name" : "chopper",
+	            "uid" : "107b5bbf-9640-4fd0-b5de-1e898e8ae9f7"
+	         },
+	         "spec" : {
+	            "ports" : [
+	               {
+	                  "port" : 10007,
+	                  "protocol" : "TCP",
+	                  "targetPort" : 8088
+	               }
+	            ]
+	         }
+	      }
+	   ]
+	}
+
+	`
+	return []byte(jsonStr), nil
+}
+
+func Test_NewK8sAPIDiscoverer(t *testing.T) {
+	Convey("NewK8sAPIDiscoverer()", t, func() {
+		Convey("returns a properly configured K8sAPIDiscoverer", func() {
+			disco := NewK8sAPIDiscoverer("127.0.0.1", "beowulf.example.com", "heorot", "/usr/local/somewhere")
+
+			So(disco.discovered, ShouldNotBeNil)
+			So(disco.ClusterIP, ShouldEqual, "127.0.0.1")
+			So(disco.ClusterHostname, ShouldEqual, "beowulf.example.com")
+			So(disco.Namespace, ShouldEqual, "heorot")
+			So(disco.Command, ShouldResemble, &KubectlDiscoveryCommand{
+				Path: "/usr/local/somewhere", Namespace: "heorot",
+			})
+		})
+	})
+}
+
+func Test_K8sHealthCheck(t *testing.T) {
+	Convey("HealthCheck() always returns 'AlwaysSuccessful'", t, func() {
+		disco := NewK8sAPIDiscoverer("127.0.0.1", "beowulf.example.com", "heorot", "/usr/local/somewhere")
+		check, args := disco.HealthCheck(nil)
+		So(check, ShouldEqual, "AlwaysSuccessful")
+		So(args, ShouldBeEmpty)
+	})
+}
+
+func Test_K8sListeners(t *testing.T) {
+	Convey("Listeners() always returns and empty slice", t, func() {
+		disco := NewK8sAPIDiscoverer("127.0.0.1", "beowulf.example.com", "heorot", "/usr/local/somewhere")
+		listeners := disco.Listeners()
+		So(listeners, ShouldBeEmpty)
+	})
+}
+
+func Test_K8sRun(t *testing.T) {
+	Convey("Run()", t, func() {
+		disco := NewK8sAPIDiscoverer("127.0.0.1", "beowulf.example.com", "heorot", "/usr/local/somewhere")
+		mock := &mockK8sDiscoveryCommand{}
+		disco.Command = mock
+
+		capture := &bytes.Buffer{}
+
+		Convey("calls the command and unmarshals the result", func() {
+			log.SetOutput(capture)
+			disco.Run(director.NewFreeLooper(director.ONCE, nil))
+			log.SetOutput(os.Stdout)
+
+			So(mock.WasCalled, ShouldBeTrue)
+			So(capture.String(), ShouldNotContainSubstring, "error")
+			So(disco.discovered, ShouldNotBeNil)
+			So(disco.discovered, ShouldNotEqual, &K8sServices{})
+			So(len(disco.discovered.Items), ShouldEqual, 1)
+			So(len(disco.discovered.Items[0].Spec.Ports), ShouldEqual, 1)
+		})
+
+		Convey("call the command and logs errors", func() {
+			mock.RunShouldError = true
+			log.SetOutput(capture)
+			disco.Run(director.NewFreeLooper(director.ONCE, nil))
+			log.SetOutput(os.Stdout)
+
+			So(mock.WasCalled, ShouldBeTrue)
+			So(capture.String(), ShouldContainSubstring, "Failed to invoke")
+		})
+
+		Convey("call the command and logs errors from the JSON output", func() {
+			mock.RunShouldReturnJunk = true
+			log.SetOutput(capture)
+			disco.Run(director.NewFreeLooper(director.ONCE, nil))
+			log.SetOutput(os.Stdout)
+
+			So(mock.WasCalled, ShouldBeTrue)
+			So(capture.String(), ShouldContainSubstring, "Failed to unmarshal json")
+		})
+	})
+}
+
+func Test_K8sServices(t *testing.T) {
+	Convey("Services()", t, func() {
+		disco := NewK8sAPIDiscoverer("127.0.0.1", "beowulf.example.com", "heorot", "/usr/local/somewhere")
+		mock := &mockK8sDiscoveryCommand{}
+		disco.Command = mock
+
+		Convey("works on a newly-created Discoverer", func() {
+			services := disco.Services()
+			So(len(services), ShouldEqual, 0)
+		})
+
+		Convey("returns the list of cached services", func() {
+			disco.Run(director.NewFreeLooper(director.ONCE, nil))
+			services := disco.Services()
+
+			So(len(services), ShouldEqual, 1)
+			svc := services[0]
+			So(svc.ID, ShouldEqual, "107b5bbf-9640-4fd0-b5de-1e898e8ae9f7")
+			So(svc.Name, ShouldEqual, "chopper")
+			So(svc.Image, ShouldEqual, "chopper:kubernetes-hosted")
+			So(svc.Created.String(), ShouldEqual, "2022-11-07 13:18:03 +0000 UTC")
+			So(svc.Hostname, ShouldEqual, "beowulf.example.com")
+			So(svc.ProxyMode, ShouldEqual, "http")
+			So(svc.Status, ShouldEqual, service.ALIVE)
+			So(svc.Updated.Unix(), ShouldBeGreaterThan, time.Now().UTC().Add(-2*time.Second).Unix())
+		})
+	})
+}

--- a/discovery/kubernetes_support.go
+++ b/discovery/kubernetes_support.go
@@ -1,0 +1,73 @@
+package discovery
+
+import (
+	"os/exec"
+	"time"
+)
+
+type K8sServices struct {
+	APIVersion string `json:"apiVersion"`
+	Items      []struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+		Metadata   struct {
+			Annotations struct {
+				KubectlKubernetesIoLastAppliedConfiguration string `json:"kubectl.kubernetes.io/last-applied-configuration"`
+			} `json:"annotations"`
+			CreationTimestamp time.Time `json:"creationTimestamp"`
+			Labels            struct {
+				Environment string `json:"Environment"`
+				ServiceName string `json:"ServiceName"`
+			} `json:"labels"`
+			Name            string `json:"name"`
+			Namespace       string `json:"namespace"`
+			ResourceVersion string `json:"resourceVersion"`
+			UID             string `json:"uid"`
+		} `json:"metadata"`
+		Spec struct {
+			ClusterIP             string   `json:"clusterIP"`
+			ClusterIPs            []string `json:"clusterIPs"`
+			InternalTrafficPolicy string   `json:"internalTrafficPolicy"`
+			IPFamilies            []string `json:"ipFamilies"`
+			IPFamilyPolicy        string   `json:"ipFamilyPolicy"`
+			Ports                 []struct {
+				Port       int    `json:"port"`
+				Protocol   string `json:"protocol"`
+				TargetPort int    `json:"targetPort"`
+			} `json:"ports"`
+			Selector struct {
+				Environment string `json:"Environment"`
+				ServiceName string `json:"ServiceName"`
+			} `json:"selector"`
+			SessionAffinity string `json:"sessionAffinity"`
+			Type            string `json:"type"`
+		} `json:"spec"`
+		Status struct {
+			LoadBalancer struct {
+			} `json:"loadBalancer"`
+		} `json:"status"`
+	} `json:"items"`
+	Kind     string `json:"kind"`
+	Metadata struct {
+		ResourceVersion string `json:"resourceVersion"`
+	} `json:"metadata"`
+}
+
+// A K8sDiscoveryCommand wraps a call to an external command that can be used
+// to discover services running on a Kubernetes cluster. This is normally
+// `kubectl` but for tests, this allows mocking out the underlying call.
+type K8sDiscoveryCommand interface {
+	Run() ([]byte, error)
+}
+
+// KubectlDiscoveryCommand is the main implementation for K8sDiscoveryCommand
+type KubectlDiscoveryCommand struct {
+	Path      string
+	Namespace string
+}
+
+func (d *KubectlDiscoveryCommand) Run() ([]byte, error) {
+	// Run `kubectl` from the specific path, and namespace, and return data as
+	// JSON, to be parsed by the Discoverer
+	return exec.Command(d.Path, "-n", d.Namespace, "get", "services", "-o", "json").CombinedOutput()
+}

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190306220146-200a235640ff
 	golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c // indirect
 	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c // indirect
-	golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/grpc v1.27.0
 	google.golang.org/protobuf v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5 h1:sM3evRHxE/1RuMe1FYAL3j7C7fUfIjkbE+NiDAYUF8U=
 golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/main.go
+++ b/main.go
@@ -136,6 +136,14 @@ func configureDiscovery(config *config.Config, publishedIP string) discovery.Dis
 				disco.Discoverers,
 				discovery.NewStaticDiscovery(config.StaticDiscovery.ConfigFile, publishedIP),
 			)
+		case "kubernetes_api":
+			disco.Discoverers = append(
+				disco.Discoverers,
+				discovery.NewK8sAPIDiscoverer(
+					config.K8sAPIDiscovery.ClusterIP, config.K8sAPIDiscovery.ClusterHostname,
+					config.K8sAPIDiscovery.Namespace, config.K8sAPIDiscovery.KubectlPath,
+				),
+			)
 		default:
 		}
 	}
@@ -301,7 +309,7 @@ func main() {
 	// Join an existing cluster by specifying at least one known member.
 	nodeCount, err := list.Join(config.Sidecar.Seeds)
 	exitWithError(err, "Failed to join cluster")
-	log.Info("Joined cluster with %d nodes contacted", nodeCount)
+	log.Infof("Joined cluster with %d nodes contacted", nodeCount)
 
 	// Set up a bunch of go-director Loopers to run our
 	// background goroutines
@@ -315,7 +323,7 @@ func main() {
 		director.FOREVER, catalog.ALIVE_SLEEP_INTERVAL, nil,
 	)
 	discoLooper := director.NewTimedLooper(
-		director.FOREVER, discovery.DefaultSleepInterval, make(chan error),
+		director.FOREVER, config.Sidecar.DiscoverySleepInterval, make(chan error),
 	)
 	listenLooper := director.NewTimedLooper(
 		director.FOREVER, discovery.DefaultSleepInterval, make(chan error),
@@ -363,7 +371,7 @@ func main() {
 
 	// This is kind of expensive because it looks at the state and formats text
 	// output on an ongoing basis. Only run in debug mode.
-	if config.Debug {
+	if config.Sidecar.Debug {
 		go announceMembers(list, state)
 	}
 


### PR DESCRIPTION
This PR is a really simple attempt to build a discovery method that allows bridging between a Sidecar cluster and a Kubernetes cluster that has been configured to have a load balancer in front of it that matches the expected ports in the Sidecar cluster. This is useful for e.g. moving services from a Mesos cluster to a Kubernetes clusters and still being able to access them in the original cluster.

It cheats by calling `kubectl` under the hood rather than loading all the of code for the K8s client into the Sidecar binary. This is both simpler and saves a lot of code hassle when building.